### PR TITLE
Fixed one of the bug occurrences

### DIFF
--- a/src/pages/favorites/favorites.ts
+++ b/src/pages/favorites/favorites.ts
@@ -10,13 +10,13 @@ import { NavController, NavParams } from 'ionic-angular';
 import { Http } from '@angular/http';
 import { MovieDetailsPage } from '../../pages/movie-details/movie-details';
 
-// import angularfire 
-import { AngularFire, FirebaseListObservable } from 'angularfire2';
+import { AngularFire } from 'angularfire2';
+import "rxjs/add/operator/first";
 
 
 /**
  * Contains logic for favorites page
- * 
+ *
  * @export
  * @class FavoritesPage
  */
@@ -25,7 +25,6 @@ import { AngularFire, FirebaseListObservable } from 'angularfire2';
   templateUrl: 'favorites.html'
 })
 export class FavoritesPage {
-  public favoritesList: FirebaseListObservable<any>;
   public movies: Array<any>;
   public userId: string;
   public favorites;
@@ -33,11 +32,11 @@ export class FavoritesPage {
 
   /**
    * Creates an instance of FavoritesPage.
-   * @param {NavController} navCtrl 
-   * @param {NavParams} navParams 
-   * @param {AngularFire} af 
-   * @param {Http} http 
-   * 
+   * @param {NavController} navCtrl
+   * @param {NavParams} navParams
+   * @param {AngularFire} af
+   * @param {Http} http
+   *
    * @memberOf FavoritesPage
    */
   constructor(public navCtrl: NavController, public navParams: NavParams, public af: AngularFire, public http: Http) {
@@ -48,7 +47,7 @@ export class FavoritesPage {
     console.log("UID for Favourites: " + this.userId);
 
     // Getting the value from the database
-    this.af.database.list('/users-favorites/' + this.userId + '/').subscribe(data => {
+    this.af.database.list('/users-favorites/' + this.userId + '/').first().subscribe(data => {
       //console.log(data);
       data.forEach(element => {
         this.favorites = element;
@@ -67,9 +66,9 @@ export class FavoritesPage {
 
   /**
    * Method that handles event when user clicks on one particular movie
-   * 
-   * @param {string} id 
-   * 
+   *
+   * @param {string} id
+   *
    * @memberOf FavoritesPage
    */
   public viewDetails(id: string) {
@@ -80,9 +79,9 @@ export class FavoritesPage {
 
   /**
    * Method that handles event when user deletes one particular movie from favorites
-   * 
-   * @param {string} id 
-   * 
+   *
+   * @param {string} id
+   *
    * @memberOf FavoritesPage
    */
   public deleteMedia(id: string) {


### PR DESCRIPTION
```src/pages/favorites/favorites.ts```:
Previously, code on line 51 created a subscription that was listening infinitely for user's favorites. After clicking log out button, the authentication state changed to _'unauthenticated'_ (or similar) and, when the action was fired inside of subscription, the 'permission denied' exception is thrown because of invalid auth state.

This issue was solved by adding ```first()``` method call to get only one instance of subscribed data and automatically unsubscribe from observable.

In case of movie-details page, the _'cannot read property uid of null'_ exception is thrown because of the same problem: the auth state is invalid (null or similar) and this line of code ```this.af.auth.subscribe(auth => this.userId = auth.uid);``` raises the exception.

This PR partially fixes #40, but there are other occurrences of similar coding practices (at least, in movie-details page) that may produce this bug.